### PR TITLE
Add page about DLCD (Department of Land Conservation and Development)

### DIFF
--- a/content/state/_index.md
+++ b/content/state/_index.md
@@ -1,8 +1,8 @@
 +++
-title = 'State Agencies'
+title = 'State'
 date = '2026-01-24'
 +++
 
-# State Agencies
+# State
 
-Oregon state agencies involved in housing policy.
+Oregon state agencies, programs, and policies related to housing.

--- a/content/state/dlcd.md
+++ b/content/state/dlcd.md
@@ -11,6 +11,8 @@ The Oregon Department of Land Conservation and Development (DLCD) is the state's
 
 DLCD was established in 1973 under Senate Bill 100, which created Oregon's nationally recognized statewide land use planning program.[^1] A seven-member volunteer citizen board known as the Land Conservation and Development Commission (LCDC) guides DLCD and adopts administrative rules that local governments must follow.
 
+The agency has approximately 115 full-time equivalent (FTE) positions as of the 2023-25 biennium budget.[^3]
+
 **Contact Information:**
 - Address: 635 Capitol Street NE, Suite 150, Salem, OR 97301
 - Phone: 503-373-0050
@@ -76,3 +78,5 @@ HAPO is a division within DLCD focused on accelerating housing production and en
 [^1]: [Oregon Department of Land Conservation and Development](https://en.wikipedia.org/wiki/Oregon_Department_of_Land_Conservation_and_Development), Wikipedia
 
 [^2]: [Required Housing Reporting](https://www.oregon.gov/lcd/housing/pages/reporting.aspx), Department of Land Conservation and Development
+
+[^3]: [2023-25 Budget Highlights](https://www.oregonlegislature.gov/lfo/Documents/2023-25%20Budget%20Highlights.pdf), Oregon Legislative Fiscal Office


### PR DESCRIPTION
This PR adds a new page about the Department of Land Conservation and Development (DLCD) at `content/state/dlcd.md`.

## Changes

- Creates new `content/state/` section for state agencies
- Adds comprehensive DLCD page covering:
  - Agency overview and history (established 1973 under SB 100)
  - Statewide Planning Goals (especially Goal 10 Housing and Goal 14 Urbanization)
  - Role in housing policy (production reporting, middle housing implementation, Housing Production Strategies)
  - Housing Accountability and Production Office (HAPO)
  - Key programs table
  - Related entities (LCDC, LUBA)
  - Links to related legislation (HB 2001, HB 2003, HB 2258)

## Sources

- Wikipedia article on DLCD
- DLCD official website (oregon.gov/lcd)
- Cross-references to existing content in the repository