### PR TITLE
Simplify legislation page title

### DIFF
--- a/content/legislation/_index.md
+++ b/content/legislation/_index.md
@@ -1,6 +1,6 @@
 +++
 date = '2026-01-11'
-title = 'Housing-Related Legislation'
+title = 'Legislation'
 bookCollapseSection = true
 +++
 


### PR DESCRIPTION
## Summary
Updated the legislation index page title from "Housing-Related Legislation" to "Legislation" for broader scope and improved clarity.

## Changes
- Changed page title from "Housing-Related Legislation" to "Legislation" in `content/legislation/_index.md`

## Details
This change removes the "Housing-Related" qualifier from the page title, allowing the legislation section to encompass a wider range of legislative content beyond just housing-related topics. The page structure and metadata remain unchanged.

https://claude.ai/code/session_01J1E7Jm2K11XTLnenrLgWtJ