### PR TITLE
Add legislation single page layout with news coverage backlinks

### DIFF
--- a/layouts/legislation/single.html
+++ b/layouts/legislation/single.html
@@ -1,0 +1,39 @@
+{{ define "main" }}
+<article class="markdown book-article">
+  <h1>{{ .Title }}</h1>
+
+  {{ .Content }}
+
+  {{/* Find news coverage that links to this legislation */}}
+  {{/* Strip trailing slash since markdown links don't include it */}}
+  {{ $currentPath := .RelPermalink | replaceRE "/$" "" }}
+  {{ $backlinks := slice }}
+  {{ range where .Site.RegularPages "Section" "news-coverage" }}
+    {{ if findRE (printf `\]\(%s\)` $currentPath) .RawContent }}
+      {{ $backlinks = $backlinks | append . }}
+    {{ end }}
+  {{ end }}
+
+  {{ if gt (len $backlinks) 0 }}
+  <h2>News Coverage</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Article</th>
+        <th>Source</th>
+        <th>Date</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{ range sort $backlinks "Date" "desc" }}
+      <tr>
+        <td><a href="{{ .Permalink }}">{{ .Title }}</a></td>
+        <td>{{ .Params.source }}</td>
+        <td>{{ .Date.Format "January 2, 2006" }}</td>
+      </tr>
+      {{ end }}
+    </tbody>
+  </table>
+  {{ end }}
+</article>
+{{ end }}


### PR DESCRIPTION
## Summary
This PR adds a new Hugo layout template for individual legislation pages that automatically displays related news coverage articles.

## Changes
- **New file**: `layouts/legislation/single.html`
  - Creates a dedicated single-page layout for legislation content
  - Renders legislation title and main content
  - Implements automatic backlink detection to find news coverage articles that reference the legislation
  - Displays related news articles in a sortable table with article title, source, and publication date

## Implementation Details
- Uses Hugo's `findRE` function to search news-coverage pages for markdown links matching the current legislation's path
- Strips trailing slashes from the permalink to match markdown link format (which typically omit trailing slashes)
- Sorts related news articles by date in descending order (newest first)
- Only displays the "News Coverage" section if backlinks are found
- Formats publication dates in a readable format (e.g., "January 2, 2006")

https://claude.ai/code/session_01S1VjfWXtpHELa6J5oZaCdM