### PR TITLE
Add dynamic legislation list template with year summaries

### DIFF
--- a/content/legislation/1973/_index.md
+++ b/content/legislation/1973/_index.md
@@ -3,3 +3,5 @@ title = '1973'
 weight = 6
 bookCollapseSection = true
 +++
+
+# 1973

--- a/content/legislation/1990/_index.md
+++ b/content/legislation/1990/_index.md
@@ -3,3 +3,5 @@ title = '1990'
 weight = 5
 bookCollapseSection = true
 +++
+
+# 1990

--- a/content/legislation/2019/_index.md
+++ b/content/legislation/2019/_index.md
@@ -3,3 +3,5 @@ title = '2019'
 weight = 4
 bookCollapseSection = true
 +++
+
+# 2019

--- a/content/legislation/2023/_index.md
+++ b/content/legislation/2023/_index.md
@@ -3,3 +3,5 @@ title = '2023'
 weight = 3
 bookCollapseSection = true
 +++
+
+# 2023

--- a/content/legislation/2024/_index.md
+++ b/content/legislation/2024/_index.md
@@ -3,3 +3,5 @@ title = '2024'
 weight = 2
 bookCollapseSection = true
 +++
+
+# 2024

--- a/content/legislation/2025/_index.md
+++ b/content/legislation/2025/_index.md
@@ -3,3 +3,5 @@ title = '2025'
 weight = 1
 bookCollapseSection = true
 +++
+
+# 2025

--- a/content/legislation/2026/_index.md
+++ b/content/legislation/2026/_index.md
@@ -3,3 +3,5 @@ title = '2026'
 weight = 1
 bookCollapseSection = true
 +++
+
+# 2026

--- a/content/legislation/_index.md
+++ b/content/legislation/_index.md
@@ -5,41 +5,4 @@ weight = 20
 bookCollapseSection = true
 +++
 
-# Oregon's Housing-Related Legislation
-
-| Date | Bill | Summary |
-|------|------|---------|
-| 2025 | [HB 2138](/legislation/2025/hb-2138) | Streamlines "middle housing" rules, creating easier paths for duplexes, triplexes, and cottage clusters. |
-| 2025 | [HB 2258](/legislation/2025/hb-2258) | Requires LCDC to adopt rules for local governments to expedite housing approvals. |
-| 2025 | [HB 3031](/legislation/2025/hb-3031) | Creates the Housing Infrastructure Project Fund for affordable housing development. |
-| 2025 | [HB 3145](/legislation/2025/hb-3145) | Allocates $25M for factory-produced housing (modular/prefab). |
-| 2025 | [SB 684](/legislation/2025/sb-684) | Amends "residential housing" to include mixed-income projects; creates loan fund. |
-| 2025 | [SB 6](/legislation/2025/sb-6) | Requires timely approval (45 business days) for housing permits. |
-| 2025 | [SB 52](/legislation/2025/sb-52) | Mandates state study on barriers to market-rate housing. |
-| 2025 | [SB 974](/legislation/2025/sb-974) | Expedites land use timeline for multi-unit developments to 45 days. |
-| 2025 | [HB 3522](/legislation/2025/hb-3522) | Simplifies process for removing squatters to return units to market. |
-| 2025 | [HB 2698](/legislation/2025/hb-2698) | Establishes statewide homeownership goal of 65% by 2030. |
-| 2025 | [HB 3746](/legislation/2025/hb-3746) | Shortens construction defect claims statute of repose to 7 years. |
-| 2025 | [SB 690](/legislation/2025/sb-690) | Delays evictions for families with infants under one year old. |
-| 2025 | [SB 973](/legislation/2025/sb-973) | Requires 30 months' notice before ending affordability programs. |
-| 2025 | [HB 3054](/legislation/2025/hb-3054) | Caps rent increases in large manufactured housing communities at 6%. |
-| 2025 | [HB 3521](/legislation/2025/hb-3521) | Enhances tenant protections regarding security deposits. |
-| 2025 | [SB 599](/legislation/2025/sb-599) | Prohibits landlords from inquiring about immigration status. |
-| 2025 | [SB 426](/legislation/2025/sb-426) | Makes property owners jointly liable for certain unpaid contractor wages. |
-| 2025 | [HB 3589](/legislation/2025/hb-3589) | Allocates $23M for senior housing development and preservation. |
-| 2025 | [HB 3644](/legislation/2025/hb-3644) | Establishes statewide shelter program with $204M funding. |
-| 2025 | [HB 3792](/legislation/2025/hb-3792) | Increases low-income energy bill assistance funding cap. |
-| 2025 | [SB 814](/legislation/2025/sb-814) | Expands rental assistance for young adults (under 25). |
-| 2025 | [SB 83](/legislation/2025/sb-83) | Repeals the statewide Wildfire Hazard Map. |
-| 2024 | [SB 1537](/legislation/2024/sb-1537) | $258M housing package; created Housing Accountability and Production Office (HAPO). |
-| 2024 | [SB 1530](/legislation/2024/sb-1530) | Part of housing package; funding for infrastructure and housing support. |
-| 2024 | [HB 4134](/legislation/2024/hb-4134) | Infrastructure grants tied to affordable housing developments. |
-| 2023 | [HB 2001](/legislation/2023/hb-2001) | Significant eviction reform (10-day notice) and Oregon Housing Needs Analysis (OHNA). |
-| 2023 | [HB 5019](/legislation/2023/hb-5019) | Affordable Housing and Emergency Homelessness Response Package. |
-| 2023 | [EO 23-04](/legislation/2023/eo-23-04) | Executive Order establishing 36,000 homes/year production goal. |
-| 2019 | [HB 2001](/legislation/2019/hb-2001) | "Middle Housing" bill; ended exclusive single-family zoning in most cities. |
-| 2019 | [HB 2003](/legislation/2019/hb-2003) | Requires cities to develop Housing Production Strategies. |
-| 2019 | [SB 608](/legislation/2019/sb-608) | Statewide rent control and "just cause" eviction protections. |
-| 2019 | [HB 2002](/legislation/2019/hb-2002) | Right of first refusal for affordable housing preservation. |
-| 1990 | [Measure 5](/legislation/1990/measure-5) | Constitutional property tax cap; shifted school funding to state. |
-| 1973 | [SB 100](/legislation/1973/sb-100) | Established statewide land use planning and Urban Growth Boundaries (UGB). |
+# Legislation

--- a/layouts/legislation/list.html
+++ b/layouts/legislation/list.html
@@ -1,0 +1,38 @@
+{{ define "main" }}
+<article class="markdown book-article">
+  {{ .Content }}
+
+  {{/* Root legislation section: show year summaries */}}
+  {{ if eq .RelPermalink "/legislation/" }}
+    {{ range sort .Sections "Title" "desc" }}
+    {{ $count := len .Pages }}
+    <h2><a href="{{ .Permalink }}">{{ .Title }}</a> ({{ $count }} bill{{ if ne $count 1 }}s{{ end }})</h2>
+    {{ .Content }}
+    {{ end }}
+
+  {{/* Year subsection: show all bills */}}
+  {{ else }}
+    <table>
+      <thead>
+        <tr>
+          <th>Bill</th>
+          <th>Summary</th>
+          <th>Sponsors</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{ range .Pages }}
+        {{ $summary := .Plain | replaceRE "#+" "" | replaceRE (printf "%s" .Title) "" | replaceRE "Original Bill Text" "" | replaceRE "\\n+" " " | replaceRE "\\s+" " " | replaceRE "^\\s+" "" | truncate 200 }}
+        <tr>
+          <td><a href="{{ .Permalink }}">{{ .Title }}</a></td>
+          <td>{{ $summary }}</td>
+          <td>{{ with .Params.sponsors }}{{ . }}{{ end }}</td>
+          <td>{{ with .Params.status }}{{ . }}{{ end }}</td>
+        </tr>
+        {{ end }}
+      </tbody>
+    </table>
+  {{ end }}
+</article>
+{{ end }}


### PR DESCRIPTION
## Summary
- Replace hardcoded bill table on `/legislation/` with a Hugo list template that dynamically shows year sections with bill counts
- Individual year pages (`/legislation/2025/` etc.) show a table of all bills with summary, sponsors, and status columns
- Add markdown headings to all `_index.md` files to fix sidebar link clickability

## Next steps
- Populate `sponsors` and `status` front matter on individual bill pages (columns are in the template but data not yet added)
- Add narrative year summaries to each year's `_index.md`

## Test plan
- [ ] Verify `/legislation/` shows year headings with correct bill counts
- [ ] Verify `/legislation/2025/` shows bill table with summaries
- [ ] Verify sidebar links for Legislation and year sections are clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)