### PR TITLE
Add WW news coverage of Oregon housing crisis data

### DIFF
--- a/content/news-coverage/2024/oregon-housing-crisis-arrived-slowly-then-all-at-once.md
+++ b/content/news-coverage/2024/oregon-housing-crisis-arrived-slowly-then-all-at-once.md
@@ -1,0 +1,9 @@
++++
+title = "New Data Shows Oregon's Housing Crisis Arrived Slowly, Then All at Once"
+date = '2024-12-04'
+source = 'Willamette Week'
+original_url = 'https://www.wweek.com/news/2024/12/04/new-data-shows-oregons-housing-crisis-arrived-slowly-then-all-at-once/'
+author = 'Nigel Jaquiss'
++++
+
+A newly released report from the Oregon Department of Housing & Community Services reveals that Oregon's population grew by three residents for every new housing unit between 2015 and 2019, significantly exceeding national averages and driving the state to rank third nationally for homelessness per capita. Governor [Tina Kotek](/people/tina-kotek) set an ambitious target of 36,000 new housing units annually through [Executive Order 23-04](/legislation/2023/eo-23-04), but Oregon is projected to permit only approximately 12,000 units in 2024, falling dramatically short despite record public investment and zoning reforms. Kotek's proposed 2025-27 budget allocates $1.4 billion toward housing initiatives, including $880 million for affordable housing bonds and $100 million for infrastructure. The report identifies two potentially favorable conditions: a robust construction industry and slower population growth, though the latter reflects housing affordability challenges rather than positive development.


### PR DESCRIPTION
## Summary
- Adds news coverage entity for Willamette Week's Dec 2024 article "New Data Shows Oregon's Housing Crisis Arrived Slowly, Then All at Once" by Nigel Jaquiss
- Creates `content/news-coverage/2024/` directory (first 2024 news coverage entry)
- Summary includes internal links to Tina Kotek and Executive Order 23-04

## Test plan
- [ ] Verify the page renders correctly with `hugo server`
- [ ] Confirm internal links to /people/tina-kotek and /legislation/2023/eo-23-04 resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)