### PR TITLE
Exclude PDF and JSON files from Hugo build

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -3,5 +3,10 @@ languageCode = 'en-us'
 title = 'Oregon Housing Project'
 theme = 'hugo-book'
 
+[[module.mounts]]
+  source = "content"
+  target = "content"
+  excludeFiles = ["legislation/**/files/**", "legislation/**/data/**"]
+
 [params]
   BookSection = '/'


### PR DESCRIPTION
## Summary

- Adds `module.mounts` configuration to `hugo.toml` to exclude `legislation/**/files/**` and `legislation/**/data/**` from the Hugo content mount
- These ~2.7 GB of PDF testimony files and JSON data files are never referenced by templates (links point to external OLIS URLs), so excluding them reduces deployment size without affecting the site

## Test plan

- [x] `hugo` builds successfully
- [x] No PDF or JSON files in `public/legislation/` output
- [x] Legislation pages still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)