### PR TITLE
Add people list page with alphabetical listing

### DIFF
--- a/content/people/_index.md
+++ b/content/people/_index.md
@@ -4,3 +4,5 @@ title = 'People'
 weight = 50
 bookCollapseSection = true
 +++
+
+Profiles of the politicians and policymakers shaping Oregon's housing policy, including legislators, city officials, and state agency leaders.

--- a/layouts/people/list.html
+++ b/layouts/people/list.html
@@ -1,0 +1,15 @@
+{{ define "main" }}
+<article class="markdown book-article">
+  <h1>{{ .Title }}</h1>
+
+  {{ .Content }}
+
+  {{ if .Pages }}
+  <ul>
+    {{ range .Pages.ByTitle }}
+    <li><a href="{{ .Permalink }}">{{ .Title }}</a></li>
+    {{ end }}
+  </ul>
+  {{ end }}
+</article>
+{{ end }}


### PR DESCRIPTION
## Changes

- Added intro text to `content/people/_index.md` describing the People section as profiles of politicians and policymakers shaping Oregon's housing policy
- Created new `layouts/people/list.html` template that displays:
  - Page title
  - Intro content
  - Alphabetically sorted list of people pages with links

This enables a dedicated People landing page with automatic listing of all individual profile pages.