### PR TITLE
Fix legislation list missing bills due to unmapped status values

### DIFF
--- a/layouts/legislation/list.html
+++ b/layouts/legislation/list.html
@@ -20,10 +20,11 @@
     {{/* Stage definitions - ordered from most to least advanced */}}
     {{ $stageGroups := slice
       (dict "name" "Signed into Law" "statuses" (slice "Chapter Number Assigned"))
+      (dict "name" "Awaiting Governor Signature" "statuses" (slice "Governors Office - Awaiting Signature" "Senate Presidents Desk - Awaiting Signature" "Senate Desk – Awaiting Transfer to Governor" "Legislative Counsel - Enrollment" "Secretary of States Office - Chapter Number Assignment"))
       (dict "name" "Near Passage" "statuses" (slice "At Presidents Desk Upon Adjournment" "In House Conference Committee" "At House Desk Upon Adjournment"))
-      (dict "name" "Awaiting Floor Vote" "statuses" (slice "Senate Desk - Awaiting Third Reading" "House Desk - Awaiting First Reading"))
-      (dict "name" "In Senate Committee" "statuses" (slice "In Senate Committee"))
-      (dict "name" "In House Committee" "statuses" (slice "In House Committee"))
+      (dict "name" "Awaiting Floor Vote" "statuses" (slice "Senate Desk - Awaiting Third Reading" "House Desk - Awaiting First Reading" "Senate Desk - Awaiting First Reading" "Senate Desk - Awaiting Second Reading" "House Desk - Second Reading" "House Desk - Third Reading" "House Desk - Awaiting Transfer to Speaker" "House Desk - PM Possible Consideration of Senate Amendments" "At Senate Desk Upon Adjournment"))
+      (dict "name" "In Senate Committee" "statuses" (slice "In Senate Committee" "In Senate Committee Awaiting transfer to Desk"))
+      (dict "name" "In House Committee" "statuses" (slice "In House Committee" "In House Committee Awaiting transfer to Desk"))
       (dict "name" "Failed" "statuses" (slice "Senate Desk - Failed" "House Desk - Failed"))
     }}
 

--- a/layouts/partials/legislation-banner.html
+++ b/layouts/partials/legislation-banner.html
@@ -6,15 +6,16 @@
 {{/* Stage definitions - ordered from most to least advanced */}}
 {{ $stageGroups := slice
   (dict "name" "Signed into Law" "statuses" (slice "Chapter Number Assigned"))
+  (dict "name" "Awaiting Governor Signature" "statuses" (slice "Governors Office - Awaiting Signature" "Senate Presidents Desk - Awaiting Signature" "Senate Desk – Awaiting Transfer to Governor" "Legislative Counsel - Enrollment" "Secretary of States Office - Chapter Number Assignment"))
   (dict "name" "Near Passage" "statuses" (slice "At Presidents Desk Upon Adjournment" "In House Conference Committee" "At House Desk Upon Adjournment"))
-  (dict "name" "Awaiting Floor Vote" "statuses" (slice "Senate Desk - Awaiting Third Reading" "House Desk - Awaiting First Reading"))
-  (dict "name" "In Senate Committee" "statuses" (slice "In Senate Committee"))
-  (dict "name" "In House Committee" "statuses" (slice "In House Committee"))
+  (dict "name" "Awaiting Floor Vote" "statuses" (slice "Senate Desk - Awaiting Third Reading" "House Desk - Awaiting First Reading" "Senate Desk - Awaiting First Reading" "Senate Desk - Awaiting Second Reading" "House Desk - Second Reading" "House Desk - Third Reading" "House Desk - Awaiting Transfer to Speaker" "House Desk - PM Possible Consideration of Senate Amendments" "At Senate Desk Upon Adjournment"))
+  (dict "name" "In Senate Committee" "statuses" (slice "In Senate Committee" "In Senate Committee Awaiting transfer to Desk"))
+  (dict "name" "In House Committee" "statuses" (slice "In House Committee" "In House Committee Awaiting transfer to Desk"))
   (dict "name" "Failed" "statuses" (slice "Senate Desk - Failed" "House Desk - Failed"))
 }}
 
 {{/* Pipeline order for banner display (least to most advanced) */}}
-{{ $pipelineOrder := slice "In House Committee" "In Senate Committee" "Awaiting Floor Vote" "Near Passage" "Signed into Law" }}
+{{ $pipelineOrder := slice "In House Committee" "In Senate Committee" "Awaiting Floor Vote" "Near Passage" "Awaiting Governor Signature" "Signed into Law" }}
 
 {{/* Count bills per stage */}}
 {{ $stageCounts := newScratch }}


### PR DESCRIPTION
Fixes #173.

## Summary

- Added new **Awaiting Governor Signature** stage covering `Governors Office - Awaiting Signature`, `Secretary of States Office - Chapter Number Assignment`, and three other related statuses
- Expanded **Awaiting Floor Vote** with 7 additional desk/reading variants
- Expanded **In Senate Committee** and **In House Committee** with "Awaiting transfer to Desk" variants
- Updated `$pipelineOrder` in the banner partial to include the new stage

All 26 tracked 2026 bills now appear on the legislation list page (previously 10 were silently dropped).

## Test plan

- [x] Started `hugo server` and verified `/legislation/2026/` shows 26 bills across Awaiting Governor Signature (16), In Senate Committee (5), and In House Committee (5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)