### PR TITLE
Capture word count and reading time for research content

### DIFF
--- a/content/research/the-elusive-cost-savings-of-the-prefabricated-home.md
+++ b/content/research/the-elusive-cost-savings-of-the-prefabricated-home.md
@@ -5,4 +5,6 @@ original_url = 'https://www.construction-physics.com/p/the-elusive-cost-savings-
 source = 'Construction Physics'
 author = 'Brian Potter'
 description = 'Despite decades of attempts to reduce housing costs through factory-built prefabrication—from 1930s panel homes to the $2 billion startup Katerra—cost savings have proven elusive, typically reaching only 10-20% over traditional methods rather than the dramatic reductions seen when manufacturing and automobiles moved from craft to industrial production. The article argues that fundamental differences between homebuilding and manufacturing (site variability, customization, transportation costs, regulatory fragmentation) have prevented prefabrication from achieving the durable efficiency gains that make reverting to old methods unthinkable.'
+word_count = 6874
+reading_time = 28
 +++

--- a/layouts/research/list.html
+++ b/layouts/research/list.html
@@ -5,7 +5,7 @@
   {{ range .Pages.ByDate.Reverse }}
   <div style="margin-bottom: 0.75rem; padding-bottom: 0.75rem; border-bottom: 1px solid var(--gray-200); font-size: 0.9375rem;">
     <h3 style="margin: 0 0 0.25rem 0; font-size: 1rem;"><a href="{{ .Params.original_url }}" target="_blank" rel="noopener">{{ .Title }}</a></h3>
-    <small style="color: var(--gray-600); font-style: italic;">{{ .Params.source }} · {{ .Date.Format "January 2, 2006" }}{{ with .Params.author }} · {{ . }}{{ end }}</small>
+    <small style="color: var(--gray-600); font-style: italic;">{{ .Params.source }} · {{ .Date.Format "January 2, 2006" }}{{ with .Params.author }} · {{ . }}{{ end }}{{ with .Params.reading_time }} · {{ . }} min read{{ end }}</small>
     {{ with .Params.description }}<div style="margin-top: 0.25rem;">{{ . }}</div>{{ end }}
   </div>
   {{ end }}

--- a/scripts/capture-research.ts
+++ b/scripts/capture-research.ts
@@ -49,6 +49,8 @@ interface PageData {
   source: string;
   date: string;
   content: string;
+  wordCount: number;
+  readingTime: number;
 }
 
 function extractPageData(html: string, url: string): PageData {
@@ -101,12 +103,18 @@ function extractPageData(html: string, url: string): PageData {
 
   const date = dateStr ? new Date(dateStr).toISOString().split('T')[0] : new Date().toISOString().split('T')[0];
 
+  const trimmedContent = content.trim();
+  const wordCount = trimmedContent ? trimmedContent.split(/\s+/).length : 0;
+  const readingTime = Math.ceil(wordCount / 250);
+
   return {
     title: title.replace(/\s+/g, ' ').trim(),
     author: author.replace(/\s+/g, ' ').trim(),
     source,
     date,
-    content: content.trim(),
+    content: trimmedContent,
+    wordCount,
+    readingTime,
   };
 }
 
@@ -160,6 +168,8 @@ async function main() {
   console.log(`  Author: ${page.author}`);
   console.log(`  Source: ${page.source}`);
   console.log(`  Date:   ${page.date}`);
+  console.log(`  Words:  ${page.wordCount}`);
+  console.log(`  Reading: ~${page.readingTime} min`);
 
   console.log('Generating description via Claude...');
   const description = await generateDescription(url, page);
@@ -168,13 +178,13 @@ async function main() {
   const slug = slugify(page.title);
   const filepath = path.join(CONTENT_DIR, `${slug}.md`);
 
-  if (fs.existsSync(filepath)) {
-    console.error(`File already exists: ${filepath}`);
-    process.exit(1);
-  }
-
   if (!fs.existsSync(CONTENT_DIR)) {
     fs.mkdirSync(CONTENT_DIR, { recursive: true });
+  }
+
+  const exists = fs.existsSync(filepath);
+  if (exists) {
+    console.log(`Updating existing file: ${filepath}`);
   }
 
   const escTitle = page.title.replace(/'/g, "''");
@@ -188,11 +198,13 @@ original_url = '${url}'
 source = '${page.source}'
 author = '${escAuthor}'
 description = '${escDescription}'
+word_count = ${page.wordCount}
+reading_time = ${page.readingTime}
 +++
 `;
 
   fs.writeFileSync(filepath, fileContent);
-  console.log(`Created: ${filepath}`);
+  console.log(`${exists ? 'Updated' : 'Created'}: ${filepath}`);
 
   // Output the filepath for use by the workflow
   console.log(`OUTPUT_FILE=${filepath}`);


### PR DESCRIPTION
## Summary
- `capture-research.ts` now computes word count and estimated reading time (250 wpm) from article content and writes `word_count` and `reading_time` to front matter
- The script now supports re-running for existing URLs (updates the file instead of erroring)
- Research list page displays reading time alongside source, date, and author
- Backfilled existing research content with word count and reading time

Closes #176

## Test plan
- [ ] Run `pnpm capture-research <url>` for a new URL and verify `word_count` and `reading_time` appear in front matter
- [ ] Re-run the script for the same URL and verify it updates rather than errors
- [ ] Run `hugo server` and verify reading time displays on the research index page

🤖 Generated with [Claude Code](https://claude.com/claude-code)